### PR TITLE
fix: Fixed inverse relationship when null using hooks

### DIFF
--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutor.cs
@@ -445,8 +445,13 @@ namespace JsonApiDotNetCore.Hooks.Internal
                 return;
             }
 
-            Dictionary<RelationshipAttribute, IEnumerable> inverse =
-                implicitAffected.ToDictionary(pair => _resourceGraph.GetInverseRelationship(pair.Key), pair => pair.Value);
+            Dictionary<RelationshipAttribute, IEnumerable> inverse = new Dictionary<RelationshipAttribute, IEnumerable>();
+            foreach(KeyValuePair<RelationshipAttribute, IEnumerable> pair in implicitAffected)
+            {
+                var inverseRelationship = _resourceGraph.GetInverseRelationship(pair.Key);
+                if (inverseRelationship != null)
+                    inverse.Add(inverseRelationship, pair.Value);
+            }            
 
             IRelationshipsDictionary resourcesByRelationship = CreateRelationshipHelper(resourceTypeToInclude, inverse);
             CallHook(container, ResourceHook.BeforeImplicitUpdateRelationship, ArrayFactory.Create<object>(resourcesByRelationship, pipeline));

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -18,8 +18,10 @@ Modified by Projekt202</Description>
     <DebugType>embedded</DebugType>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <AssemblyName>Projekt202.JsonApiDotNetCore</AssemblyName>
-    <Version>4.1.2</Version>
+    <Version>4.1.2.1</Version>
     <RepositoryUrl>https://github.com/projekt202/JsonApiDotNetCore</RepositoryUrl>
+    <AssemblyVersion>4.1.2.1</AssemblyVersion>
+    <FileVersion>4.1.2.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
When using hooks, if an inverse relationship is null, an exception is thrown. Inverse relationships are optional, not required.
